### PR TITLE
SDD-704 - Include Priority Groups Serializer

### DIFF
--- a/NCS.DSS.Customer/Models/Customer.cs
+++ b/NCS.DSS.Customer/Models/Customer.cs
@@ -93,7 +93,7 @@ namespace NCS.DSS.Customer.Models
         [Required]
         [Display(Description = "Priority Customer reference data.")]
         [Example(Description = "[2,3]")]
-        //[JsonConverter(typeof(PriorityGroupConverter))]
+        [JsonConverter(typeof(PriorityGroupConverter))]
         public List<PriorityCustomer> PriorityGroups { get; set; }
 
         [JsonIgnoreOnSerialize]


### PR DESCRIPTION
Fix bug with string arrays not working for customer.

PriorityGroups used to allowed the format "[1,2,3]" & [1,2,3], but a change was made so that only [1,2,3] is allowed. This PR fixes this issue and reverts back to allowing both "[1,2,3]" & [1,2,3]  