### PR TITLE
DSS Release 2.1 (.NET 6.0)

### DIFF
--- a/NCS.DSS.Customer.Tests/NCS.DSS.Customer.Tests.csproj
+++ b/NCS.DSS.Customer.Tests/NCS.DSS.Customer.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>portable</DebugType>
@@ -15,21 +15,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Search.Documents" Version="11.4.0" />
     <PackageReference Include="DFC.Common.Standard" Version="0.1.4" />
     <PackageReference Include="DFC.Functions.DI.Standard" Version="0.1.0" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.20" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-    <PackageReference Include="Moq" Version="4.14.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.27" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.4" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NCS.DSS.Customer\NCS.DSS.Customer.csproj" />

--- a/NCS.DSS.Customer.sln
+++ b/NCS.DSS.Customer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30621.155
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NCS.DSS.Customer", "NCS.DSS.Customer\NCS.DSS.Customer.csproj", "{240870A9-A13D-42C4-BF01-0A53339AB51F}"
 EndProject
@@ -13,12 +13,12 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{240870A9-A13D-42C4-BF01-0A53339AB51F}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{240870A9-A13D-42C4-BF01-0A53339AB51F}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{240870A9-A13D-42C4-BF01-0A53339AB51F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{240870A9-A13D-42C4-BF01-0A53339AB51F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{240870A9-A13D-42C4-BF01-0A53339AB51F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{240870A9-A13D-42C4-BF01-0A53339AB51F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D9BEE22A-B8DB-4B46-8069-400DDF26CD9B}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{D9BEE22A-B8DB-4B46-8069-400DDF26CD9B}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{D9BEE22A-B8DB-4B46-8069-400DDF26CD9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9BEE22A-B8DB-4B46-8069-400DDF26CD9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9BEE22A-B8DB-4B46-8069-400DDF26CD9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9BEE22A-B8DB-4B46-8069-400DDF26CD9B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/NCS.DSS.Customer/Cosmos/Provider/DocumentDBProvider.cs
+++ b/NCS.DSS.Customer/Cosmos/Provider/DocumentDBProvider.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Documents.Linq;
-using Microsoft.Azure.Search;
-using Microsoft.Azure.Search.Models;
 using NCS.DSS.Customer.Cosmos.Client;
 using NCS.DSS.Customer.Cosmos.Helper;
 using NCS.DSS.Customer.Models;
@@ -62,43 +60,6 @@ namespace NCS.DSS.Customer.Cosmos.Provider
             {
                 return false;
             }
-        }
-
-        public async Task<List<Models.Customer>> SearchCustomer(ISearchIndexClient indexClient, string searchText,
-            string filter = null, IList<string> order = null, IList<string> facets = null)
-        {
-            var sp = new SearchParameters
-            {
-                QueryType = QueryType.Full,
-                SearchMode = SearchMode.All,
-                IncludeTotalResultCount = true,
-                Top = 1000
-            };
-
-            //Add Filter
-            if (!string.IsNullOrEmpty(filter))
-            {
-                sp.Filter = filter;
-            }
-
-            //Order
-            if (order != null && order.Count > 0)
-            {
-                sp.OrderBy = order;
-            }
-
-            //facets
-            if (facets != null && facets.Count > 0)
-            {
-                sp.Facets = facets;
-            }
-
-            DocumentSearchResult<Models.Customer> response;
-
-            //Search
-            response = await indexClient.Documents.SearchAsync<Models.Customer>(searchText, sp);
-
-            return response?.Results.Count == 0 ? null : response?.Results.Select(result => result.Document).ToList();
         }
 
         public async Task<List<Models.Customer>> GetAllCustomer()

--- a/NCS.DSS.Customer/Cosmos/Provider/IDocumentDBProvider.cs
+++ b/NCS.DSS.Customer/Cosmos/Provider/IDocumentDBProvider.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Search;
 using NCS.DSS.Customer.Models;
 using System;
 using System.Collections.Generic;
@@ -12,9 +11,6 @@ namespace NCS.DSS.Customer.Cosmos.Provider
     {
         Task<bool> DoesCustomerResourceExist(Guid customerId);
         Task<bool> DoesCustomerHaveATerminationDate(Guid customerId);
-
-        Task<List<Models.Customer>> SearchCustomer(ISearchIndexClient indexClient, string searchText,
-            string filter = null, IList<string> order = null, IList<string> facets = null);
 
         Task<List<Models.Customer>> GetAllCustomer();
         Task<Models.Customer> GetCustomerByIdAsync(Guid customerId);

--- a/NCS.DSS.Customer/Helpers/SearchHelper.cs
+++ b/NCS.DSS.Customer/Helpers/SearchHelper.cs
@@ -1,36 +1,29 @@
-﻿using System;
-using Microsoft.Azure.Search;
+﻿using Azure;
+using Azure.Search.Documents;
+using System;
+
 
 namespace NCS.DSS.Customer.Helpers
 {
     public static class SearchHelper
-    {        
+    {
+        // https://learn.microsoft.com/en-us/azure/search/search-dotnet-sdk-migration-version-11
+
         private static readonly string SearchServiceName = Environment.GetEnvironmentVariable("SearchServiceName");
         private static readonly string SearchServiceKey = Environment.GetEnvironmentVariable("SearchServiceAdminApiKey");
         private static readonly string SearchServiceIndexName = Environment.GetEnvironmentVariable("CustomerSearchIndexName");
 
-        private static SearchServiceClient _serviceClient;
-        private static ISearchIndexClient _indexClient;
+        private static SearchClient _client;
 
-        public static SearchServiceClient GetSearchServiceClient()
+        public static SearchClient GetSearchServiceClient()
         {
-            if (_serviceClient != null)
-                return _serviceClient;
+            if (_client != null)
+                return _client;
 
-            _serviceClient = new SearchServiceClient(SearchServiceName, new SearchCredentials(SearchServiceKey));
+            _client = new SearchClient(new Uri($"https://{SearchServiceName}.search.windows.net"), SearchServiceIndexName, new AzureKeyCredential(SearchServiceKey));
 
-            return _serviceClient;
+            return _client;
         }
-        
-        public static ISearchIndexClient GetIndexClient()
-        {
-            if (_indexClient != null)
-                return _indexClient;
-
-            _indexClient = _serviceClient?.Indexes?.GetClient(SearchServiceIndexName);
-
-            return _indexClient;
-        }
-
+      
     }
 }

--- a/NCS.DSS.Customer/Models/CustomerSearch.cs
+++ b/NCS.DSS.Customer/Models/CustomerSearch.cs
@@ -37,9 +37,6 @@ namespace NCS.DSS.Customer.Models
         public DateTime? LastModifiedDate { get; set; }
 
         public string LastModifiedTouchpointId { get; set; }
-
-        public List<PriorityCustomer> PriorityGroups { get; set; }
-
     }
 
 }

--- a/NCS.DSS.Customer/NCS.DSS.Customer.csproj
+++ b/NCS.DSS.Customer/NCS.DSS.Customer.csproj
@@ -1,25 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>    
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.4.0" />
     <PackageReference Include="DFC.Common.Standard" Version="0.1.4" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.20" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.1" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.27" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.Search" Version="5.0.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.47.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.4" />
   </ItemGroup>  
   <ItemGroup>
     <None Update="local.host.json">

--- a/Resources/deployments/function-app-resources.json
+++ b/Resources/deployments/function-app-resources.json
@@ -56,6 +56,7 @@
         "serverFarmId": "[parameters('appServicePlanId')]",
         "siteConfig": {
           "alwaysOn": true,
+          "netFrameworkVersion": "v6.0",
           "minTlsVersion": "1.2",
           "appSettings": [
             {
@@ -64,7 +65,7 @@
             },
             {
               "name": "FUNCTIONS_EXTENSION_VERSION",
-              "value": "~3"
+              "value": "~4"
             },
             {
               "name": "MSDEPLOY_RENAME_LOCKED_FILES",


### PR DESCRIPTION
* POC for .NET 6 upgrade

* Upgraded function app runtime from v3 to v4

* Updated Configuration setting for function app runtime

* Updated Azure.Messaging.ServiceBus

Add nuget Azure.Messaging.ServiceBus to hoist other version of package up to resolve issue with posting to service bus

* Updated formatting of search uri due to new version of SDK

* Removed unused search fields

New version of SDK logs error when sending to azure search

* Fix warning about pinned to unsupported version