### PR TITLE
AD-221895: Fix SyncDataForCustomerSearchTrigger function name error

### DIFF
--- a/NCS.DSS.Customer/AzureSearchDataSyncTrigger/CustomerSearchDataSyncTrigger.cs
+++ b/NCS.DSS.Customer/AzureSearchDataSyncTrigger/CustomerSearchDataSyncTrigger.cs
@@ -15,7 +15,7 @@ namespace NCS.DSS.Customer.AzureSearchDataSyncTrigger
         }
 
         [Function("SyncDataForCustomerSearchTrigger")]
-        public async Task RunAsync(
+        public async Task Run(
             [CosmosDBTrigger("customers", "customers", ConnectionStringSetting = "CustomerConnectionString",
                 LeaseCollectionName = "customers-leases", CreateLeaseCollectionIfNotExists = true)]
             IReadOnlyList<Models.CustomerDocument> documents)


### PR DESCRIPTION
Error message: "Exception while executing function: Functions.SyncDataForCustomerSearchTrigger Result: Failure
Exception: System.InvalidOperationException: Method 'Run' specified in EntryPoint was not found."