### PR TITLE
Upgrade Swagger to 0.1.36

### DIFF
--- a/NCS.DSS.Customer.Tests/NCS.DSS.Customer.Tests.csproj
+++ b/NCS.DSS.Customer.Tests/NCS.DSS.Customer.Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="DFC.Functions.DI.Standard" Version="0.1.0" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.7.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/NCS.DSS.Customer.Tests/ValidationTests/ValidateTests.cs
+++ b/NCS.DSS.Customer.Tests/ValidationTests/ValidateTests.cs
@@ -30,8 +30,7 @@ namespace NCS.DSS.Customer.Tests.ValidationTests
             // Assert
             Assert.That(result, Is.InstanceOf<List<ValidationResult>>());
             Assert.That(result, Is.Not.Null);
-            //Changed to 5 as PriorityGroups are now required
-            Assert.That(result.Count, Is.EqualTo(5));
+            Assert.That(result.Count, Is.EqualTo(3));
         }
 
         [Test]
@@ -46,7 +45,7 @@ namespace NCS.DSS.Customer.Tests.ValidationTests
             // Assert
             Assert.That(result, Is.InstanceOf<List<ValidationResult>>());
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -61,7 +60,7 @@ namespace NCS.DSS.Customer.Tests.ValidationTests
             // Assert
             Assert.That(result, Is.InstanceOf<List<ValidationResult>>());
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -241,7 +240,7 @@ namespace NCS.DSS.Customer.Tests.ValidationTests
             // Assert
             Assert.That(result, Is.InstanceOf<List<ValidationResult>>());
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result.Count, Is.EqualTo(1));
         }
 
 
@@ -257,7 +256,7 @@ namespace NCS.DSS.Customer.Tests.ValidationTests
             // Assert
             Assert.That(result, Is.InstanceOf<List<ValidationResult>>());
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result.Count, Is.EqualTo(1));
         }
 
         [Test]
@@ -272,7 +271,7 @@ namespace NCS.DSS.Customer.Tests.ValidationTests
             // Assert
             Assert.That(result, Is.InstanceOf<List<ValidationResult>>());
             Assert.That(result, Is.Not.Null);
-            Assert.That(result.Count, Is.EqualTo(7));
+            Assert.That(result.Count, Is.EqualTo(4));
         }
     }
 }

--- a/NCS.DSS.Customer/NCS.DSS.Customer.csproj
+++ b/NCS.DSS.Customer/NCS.DSS.Customer.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.Search.Documents" Version="11.5.1" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.JSON.Standard" Version="0.1.4" />
-    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.30" />
+    <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />


### PR DESCRIPTION
1. Removed Swagger package references from Tests Project which is not required
2. Fixed failed validation unit test cases
3. Upgraded Swagger to 0.1.36 on Customer project